### PR TITLE
Corrige fechamento incorreto da tag h3 na página 'inserindo js'

### DIFF
--- a/manual/js/inserindo-js.html
+++ b/manual/js/inserindo-js.html
@@ -31,7 +31,7 @@ title: Inserindo JS na página?
 	<pre class="lang-html prettyprint linenums">
 	&lt;script type="text/javascript" src="js/meu-arquivo.js"&gt;&lt;/script&gt;
 	</pre>
-	<h3>Exemplo 2 - adicionando um JavaScript da internet:</p>
+	<h3>Exemplo 2 - adicionando um JavaScript da internet:</h3>
 	<p>Nesse exemplo, é carregado o <a href="o-que-framework.html"><i>framework</i></a> JavaScript <a href="o-que-jquery.html">jQuery</a> disponibilizado pela Google por um serviço de hospedagem de <i>libraries</i> (bibliotecas) JavaScript. Disponível em <a href="https://developers.google.com/speed/libraries/devguide?hl=pt-br#jquery" target="_blank">https://developers.google.com/speed/libraries/devguide?hl=pt-br#jquery</a>:</p>
 	<pre class="lang-html prettyprint linenums">
 	&lt;script 


### PR DESCRIPTION
Este commit simplesmente corrige o fechamento de uma tag <h3> na página relacionada a inserção de arquivos javascript na página.
