### PR TITLE
Correção html página "o que são metatags"

### DIFF
--- a/manual/html/oquemetatags.html
+++ b/manual/html/oquemetatags.html
@@ -7,8 +7,9 @@ title: O que são metatags?
 <article class="content">
   <h1>O que são metatags?</h1>
   <h2>Informação sobre seu site</h2>
-    <p>A <strong>Meta Tag</strong>, representada pela tag &lt;meta&gt; é uma tag diferenciada das demais por não ter nenhum efeito aparente na página em si, mas sim por ser responsável por ações externas à página, como por exemplo informar à buscadores como Google ou Bing algumas informações a respeito da página, como título e uma breve descrição.</p>
-    <h2>Tipos de Meta Tags</h2>
+  <p>A <strong>Meta Tag</strong>, representada pela tag &lt;meta&gt; é uma tag diferenciada das demais por não ter nenhum efeito aparente na página em si, mas sim por ser responsável por ações externas à página, como por exemplo informar à buscadores como Google ou Bing algumas informações a respeito da página, como título e uma breve descrição.</p>
+  <h2>Tipos de Meta Tags</h2>
+  <dl>
     <dt>Author</dt>
     <dd><p>O nome do autor da página.</p></dd>
     <dt>Copyright</dt>
@@ -19,6 +20,6 @@ title: O que são metatags?
     <dd><p>Data em que o documento deve ser considerado expirado.</p></dd>
     <dt>Keywords</dt>
     <dd><p>Aqui é um dos locais onde os motores de busca procuram informações a respeito da página.</p></dd>
-    
+  </dl>
   <p>Esta página está em construção. Volte em breve ou <a href="https://github.com/tableless/iniciantes">ajude a completá-la</a>!</p>
 </article>


### PR DESCRIPTION
Metatags - Correção de html. Existem `dt`'s e `dd`'s, mas não existe uma `dl` envelopando tudo. Coloquei a dl 

![pr-metatags](https://cloud.githubusercontent.com/assets/400922/9553428/5ffaa996-4d95-11e5-8aed-153b32a9e2d1.JPG)
