### PR TITLE
Comentario alterado referente ao resultado do valor de um Array

### DIFF
--- a/manual/js/arrays.html
+++ b/manual/js/arrays.html
@@ -75,6 +75,6 @@ gaveteiro.push(300);
 gaveteiro.push(400);
 console.log(gaveteiro.length); //10
 gaveteiro.push(200);
-console.log(gaveteiro.length); //9
+console.log(gaveteiro.length); //11
 </pre>
 </article>


### PR DESCRIPTION
Alterado o comentario de //9 para //11 na ultima linha :

var  gaveteiro = [1,2,3,10,20,30];
console.log(gaveteiro.length); //6
gaveteiro.push(100);
gaveteiro.push(200);
gaveteiro.push(300);
gaveteiro.push(400);
console.log(gaveteiro.length); //10
gaveteiro.push(200);
console.log(gaveteiro.length); //11